### PR TITLE
Allow semigroupoids 5.1.

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -63,7 +63,7 @@ library
                      , mtl           < 2.3  && >= 2.0
                      , process       < 1.7  && >= 1.1.0.1
                      , unix          < 2.8  && >= 2.5.1.1
-                     , semigroupoids < 5.3  && >= 5.2.1
+                     , semigroupoids < 5.3  && >= 5.2
                      , ghc-prim
 
 -- [Note ghc-prim]

--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -63,7 +63,7 @@ library
                      , mtl           < 2.3  && >= 2.0
                      , process       < 1.7  && >= 1.1.0.1
                      , unix          < 2.8  && >= 2.5.1.1
-                     , semigroupoids < 5.3  && >= 5.2
+                     , semigroupoids < 5.3  && >= 5.1
                      , ghc-prim
 
 -- [Note ghc-prim]


### PR DESCRIPTION
This allows to use cabal-helper, and thus HIE, to be used on
the packages in NixOS 17.03.