### PR TITLE
Add "dist-dir" command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ cabal.sandbox.config
 
 # Emacs lock files
 .#*
+
+/dist-newstyle
+/.ghc.environment.*
+

--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -348,7 +348,7 @@ reconfigure readProc progs cabalOpts = do
                  then [ "--with-ghc-pkg=" ++ ghcPkgProgram progs ]
                  else []
             ++ cabalOpts
-    _ <- liftIO $ readProc (cabalProgram progs) ("configure":progOpts) ""
+    _ <- liftIO $ readProc (cabalProgram progs) ("new-configure":progOpts) ""
     return ()
 
 readHelper :: (MonadIO m, MonadQuery m) => [String] -> m [Maybe ChResponse]

--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -369,7 +369,6 @@ reconfigure readProc progs cabalOpts = do
 readHelper :: (MonadIO m, MonadQuery m) => [String] -> m [Maybe ChResponse]
 readHelper args = ask >>= \qe -> liftIO $ do
   out <- either error id <$> invokeHelper qe args
-  liftIO $ putStrLn $ ">>>> " ++ out
   let res = read out
   liftIO $ evaluate res `E.catch` \se@(SomeException _) -> do
       md <- lookupEnv' "CABAL_HELPER_DEBUG"

--- a/src/CabalHelper/Compiletime/Wrapper.hs
+++ b/src/CabalHelper/Compiletime/Wrapper.hs
@@ -32,6 +32,7 @@ import System.FilePath
 import System.IO
 import System.Process
 import Text.Printf
+import Text.Show.Pretty
 
 import qualified Data.Text as Text
 import qualified Data.Map.Strict as Map
@@ -156,17 +157,19 @@ main = handlePanic $ do
     "print-appdatadir":[] -> putStrLn =<< appCacheDir
     "print-appcachedir":[] -> putStrLn =<< appCacheDir
     "print-build-platform":[] -> putStrLn $ display buildPlatform
-    projdir:_distdir:"dist-dir":[] -> do
+    "v1-style":projdir:_distdir:"dist-dir":[] -> do
       let bp = display buildPlatform
       ghcVersion <- reverse . takeWhile (/= ' ') . reverse . takeWhile (/= '\n') <$> readProcess "ghc" ["--version"] ""
       [cfile] <- filter isCabalFile <$> getDirectoryContents projdir
       gpd <- readPackageDescription silent (projdir </> cfile)
       let pkgName     = display (packageName gpd) :: String
       let pkgVersion  = display (toDataVersion (packageVersion gpd)) :: String
+      let path = "dist-newstyle/build" </> bp </> ("ghc-" <> ghcVersion) </> pkgName <> "-" <> pkgVersion
+      let distDirPath = ChResponseDistDir path
 
-      putStr $ "dist-newstyle/build" </> bp </> ("ghc-" <> ghcVersion) </> pkgName <> "-" <> pkgVersion
+      putStr . show $ [Just distDirPath]
 
-    "oldstyle":projdir:_distdir:"package-id":[] -> do
+    "v1-style":projdir:_distdir:"package-id":[] -> do
       let v | oVerbose opts = deafening
             | otherwise    = silent
       -- ghc-mod will catch multiple cabal files existing before we get here

--- a/src/CabalHelper/Shared/InterfaceTypes.hs
+++ b/src/CabalHelper/Shared/InterfaceTypes.hs
@@ -13,7 +13,9 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, DefaultSignatures #-}
+{-# LANGUAGE DefaultSignatures  #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
 
 {-|
 Module      : CabalHelper.Shared.InterfaceTypes
@@ -31,8 +33,8 @@ talking to an old executable.
 -}
 module CabalHelper.Shared.InterfaceTypes where
 
-import GHC.Generics
 import Data.Version
+import GHC.Generics
 
 data ChResponse
     = ChResponseCompList    [(ChComponentName, [String])]
@@ -44,6 +46,7 @@ data ChResponse
     | ChResponseVersion     String Version
     | ChResponseLicenses    [(String, [(String, Version)])]
     | ChResponseFlags       [(String, Bool)]
+    | ChResponseDistDir     String
   deriving (Eq, Ord, Read, Show, Generic)
 
 data ChComponentName = ChSetupHsName
@@ -67,8 +70,8 @@ data ChEntrypoint = ChSetupEntrypoint -- ^ Almost like 'ChExeEntrypoint' but
                                     , chOtherModules   :: [ChModuleName]
                                     , chSignatures     :: [ChModuleName] -- backpack only
                                     }
-                  | ChExeEntrypoint { chMainIs         :: FilePath
-                                    , chOtherModules   :: [ChModuleName]
+                  | ChExeEntrypoint { chMainIs       :: FilePath
+                                    , chOtherModules :: [ChModuleName]
                                     } deriving (Eq, Ord, Read, Show, Generic)
 
 data ChPkgDb = ChPkgGlobal


### PR DESCRIPTION
For anything that wants to discover the directory that contains `setup-config`.
Also change `cabal configure` to `cabal new-configure`.

```
~/src/play/haskell-ide-engine/.stack-work/install/x86_64-osx/lts-12.11/8.4.3/libexec/x86_64-osx-ghc-8.4.3/cabal-helper-1.0.0.0/cabal-helper-wrapper "--with-ghc=ghc" "--with-ghc-pkg=ghc-pkg" "--with-cabal=cabal" "v1-style" "/Users/david/src/arbor/mayhem/hw-ip" "/Users/david/src/arbor/mayhem/hw-ip/dist-newstyle/build/x86_64-osx/ghc-8.4.3/hw-ip-0.4.1" dist-dir
[Just (ChResponseDistDir "dist-newstyle/build/x86_64-osx/ghc-8.4.3/hw-ip-0.4.1")]
```